### PR TITLE
analyze_osc_data: fix genalyzer import

### DIFF
--- a/analyze_osc_data/analyze_osc_data.py
+++ b/analyze_osc_data/analyze_osc_data.py
@@ -24,7 +24,7 @@ import argparse
 import matplotlib
 
 import numpy as np
-import genalyzer.advanced as gn
+import genalyzer as gn
 import matplotlib.pyplot as pl
 import pandas as pd
 


### PR DESCRIPTION
As of genalyzer commit a7d410c20cee the "advanced" name is no longer used, which means this script won't work as-is. Update the genalyzer import so it works again.